### PR TITLE
hack: display initial empty netzgrafik

### DIFF
--- a/src/app/sample-netzgrafik/netzgrafik.default.ts
+++ b/src/app/sample-netzgrafik/netzgrafik.default.ts
@@ -8,6 +8,29 @@ import {NetzgrafikDemoStandaloneGithub} from "./netzgrafik.demo.standalone.githu
 
 export class NetzgrafikDefault {
   static getDefaultNetzgrafik(): NetzgrafikDto {
+    return {
+      nodes: [],
+      trainrunSections: [],
+      trainruns: [],
+      resources: [],
+      metadata: {
+        analyticsSettings: {
+          originDestinationSettings: {
+            connectionPenalty: 5,
+          }
+        },
+        trainrunCategories: [],
+        trainrunFrequencies: [],
+        trainrunTimeCategories: [],
+        netzgrafikColors: [],
+      },
+      freeFloatingTexts: [],
+      labels: [],
+      labelGroups: [],
+      filterData: {
+        filterSettings: [],
+      },
+    };
     if (environment.standalonedemo) {
       return NetzgrafikDemoStandaloneGithub.getNetzgrafikDemoStandaloneGithub();
     }


### PR DESCRIPTION
# Description

Hack to prevent blinking issues at NGE loading, when loading a timetable

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [ ] This PR contains a description of the changes I'm making
* [ ] I've read the [Contribution Guidelines](https://github.com/SchweizerischeBundesbahnen/netzgrafik-editor-frontend/blob/main/CONTRIBUTING.md)
* [ ] I've added tests for changes or features I've introduced
* [ ] I documented any high-level concepts I'm introducing in `documentation/`
* [ ] CI is currently green and this is ready for review

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation.
-->
