### PR TITLE
hack: remove category shortName from trainrun name displays

### DIFF
--- a/src/app/perlenkette/perlenkette.component.html
+++ b/src/app/perlenkette/perlenkette.component.html
@@ -25,8 +25,7 @@
               (click)="trainrunNameClicked($event)"
             >
               <span class="trainname"
-              >{{ perlenketteTrainrun.categoryShortName
-                }}{{ perlenketteTrainrun.title }}</span
+              >{{ perlenketteTrainrun.title }}</span
               >
             </p>
 

--- a/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
+++ b/src/app/view/dialogs/trainrun-and-section-dialog/trainrun-and-section-dialog.component.html
@@ -16,9 +16,7 @@
     <div class="TrainrunTabGrupe">
       <sbb-tab-group [selectedIndex]="data.type">
         <sbb-tab
-          label="{{ selectedTrainrun.getCategoryShortName() }}{{
-            selectedTrainrun.getTitle()
-          }}"
+          label="{{ selectedTrainrun.getTitle() }}"
           id="trainrun-tab"
         >
           <sbb-trainrun-tab

--- a/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
+++ b/src/app/view/editor-main-view/data-views/trainrunsections.view.ts
@@ -494,10 +494,7 @@ export class TrainrunSectionsView {
   }
 
   static extractTrainrunName(trainrunSection: TrainrunSection): string {
-    return (
-      trainrunSection.getTrainrun().getCategoryShortName() +
-      trainrunSection.getTrainrun().getTitle()
-    );
+    return trainrunSection.getTrainrun().getTitle();
   }
 
   static extractTravelTime(


### PR DESCRIPTION
Remove the category shortName from the trainrun name displays

![Capture d'écran 2025-06-04 163904](https://github.com/user-attachments/assets/f6eea6e6-e853-461a-9841-184b1fa76b4d)
![Capture d'écran 2025-06-04 163942](https://github.com/user-attachments/assets/4e72b45d-f8e0-4055-ada0-050d9934fe3b)
![image](https://github.com/user-attachments/assets/20e315d3-fb65-402f-b270-dc44f39481df)
