### PR TITLE
ci: make npm publication use trusted publishers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,12 +131,11 @@ jobs:
         with:
           name: build-standalone
           path: dist/netzgrafik-frontend/
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm pkg set name="@osrd-project/netzgrafik-frontend"
       - run: npm version --no-git-tag-version "0.0.0-snapshot.$GITHUB_SHA"
       - run: npm pkg delete dependencies optionalDependencies devDependencies
       - run: npm publish --provenance --access public --tag snapshot
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
See https://docs.npmjs.com/trusted-publishers

Not sure: 
- Does it make sense to have these changes only on the fork side?
- No way to check that it works