### PR TITLE
hack: disable space-time diagram

### DIFF
--- a/src/app/view/editor-menu/editor-menu.component.html
+++ b/src/app/view/editor-menu/editor-menu.component.html
@@ -342,7 +342,7 @@
   </div>
 
   <div class="NodeStreckengrafik">
-    <ng-container *ngIf="!isStreckengrafikEditing()">
+    <ng-container *ngIf="false">
       <button
         mode="icon"
         class="ButtonStreckengrafikEditor NetzgrafikEditing"
@@ -359,7 +359,7 @@
         ></sbb-icon>
       </button>
     </ng-container>
-    <ng-container *ngIf="isStreckengrafikEditing()">
+    <ng-container *ngIf="false">
       <button
         mode="icon"
         class="ButtonStreckengrafikEditor StreckengrafikEditing"


### PR DESCRIPTION
NGE STD is not needed in OSRD since it already has its own STD.