### PR TITLE
fixup! hack: disable space-time diagram NGE STD is not needed in OSRD…

### DIFF
--- a/src/app/view/editor-properties-view-component/editor-properties-view.component.html
+++ b/src/app/view/editor-properties-view-component/editor-properties-view.component.html
@@ -153,7 +153,7 @@
     </sbb-radio-group>
   </sbb-expansion-panel>
 
-  <sbb-expansion-panel [expanded]="true">
+  <sbb-expansion-panel [expanded]="true" *ngIf="false">
     <sbb-expansion-panel-header>{{
       "app.view.editor-properties-view-component.graphicTimetable" | translate
     }}</sbb-expansion-panel-header>


### PR DESCRIPTION
… since it already has its own STD.

<img width="1910" height="911" alt="image" src="https://github.com/user-attachments/assets/4b3eb2a9-306e-4a13-9559-2ac5036616a0" />

^This section should not be displayed either