### PR TITLE
fixup! hack: allow times to be unset

### DIFF
--- a/src/app/data-structures/technical.data.structures.ts
+++ b/src/app/data-structures/technical.data.structures.ts
@@ -109,10 +109,10 @@ export interface TimeFormatter {
  */
 export interface TimeLockDto {
   time: number | null; // minutes [0..60]
-  consecutiveTime: number; // automatically updated after any data changes in the application
+  consecutiveTime: number | null; // automatically updated after any data changes in the application
   lock: boolean; // used to stop the time propagation (forward/backward)
-  warning?: WarningDto; // warning - if business logic detects an issue -> set human-readable warning
-  timeFormatter?: TimeFormatter; // undefined or object - optional
+  warning?: WarningDto | null; // warning - if business logic detects an issue -> set human-readable warning
+  timeFormatter?: TimeFormatter | null; // undefined or object - optional
 }
 
 /**


### PR DESCRIPTION
This is required for the type import migration (see https://github.com/OpenRailAssociation/netzgrafik-editor-frontend/pull/1143).

This fixes this error downstream:
``` sh
  × typescript(TS2322): Type 'null' is not assignable to type 'WarningDto | undefined'.
     ╭─[src/applications/operationalStudies/views/Scenario/components/MacroEditor/osrdToNge.ts:419:3]
 418 │   lock: false,
 419 │   warning: null,
     ·   ───────
 420 │   timeFormatter: null,
     ╰────
```